### PR TITLE
Feat/move focus using keyboard

### DIFF
--- a/src/newtab/components/BookmarkView.tsx
+++ b/src/newtab/components/BookmarkView.tsx
@@ -111,7 +111,7 @@ const BookmarkView = ({
       onDoubleClick={() => onDoubleClick?.(bookmark)}
     >
       <button
-        className="relative flex size-full cursor-default flex-col items-center gap-1 bg-transparent"
+        className="relative flex size-full cursor-default flex-col items-center gap-1 bg-transparent focus:outline-none"
         ref={containerRef}
       >
         <div

--- a/src/newtab/components/BookmarkView.tsx
+++ b/src/newtab/components/BookmarkView.tsx
@@ -13,6 +13,7 @@ type Props = {
   isEdit?: boolean;
   setIsEdit?: (isEdit: boolean) => void;
   isDragging?: boolean;
+  isCurrentFocusCursor?: boolean;
 };
 declare module "react" {
   interface CSSProperties {
@@ -35,6 +36,7 @@ const BookmarkView = ({
   isEdit,
   setIsEdit,
   isDragging,
+  isCurrentFocusCursor,
 }: Props) => {
   const [newTitle, setNewTitle] = useState<string>(bookmark.title);
 
@@ -50,6 +52,12 @@ const BookmarkView = ({
   useEffect(() => {
     setNewTitle(bookmark.title);
   }, [bookmark.title]);
+
+  useEffect(() => {
+    if (isCurrentFocusCursor) {
+      containerRef.current?.focus();
+    }
+  }, [isCurrentFocusCursor]);
 
   const saveTitle = async () => {
     if (!isEdit) {

--- a/src/newtab/components/Bookshelf.tsx
+++ b/src/newtab/components/Bookshelf.tsx
@@ -1,11 +1,11 @@
-import type {FC} from "react";
-import {useEffect, useMemo, useRef} from "react";
-import {type Bookmark} from "../../types/store";
-import {ITEM_HEIGHT, ITEM_WIDTH} from "../utils/constant";
+import type { FC } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import { type Bookmark } from "../../types/store";
+import { ITEM_HEIGHT, ITEM_WIDTH } from "../utils/constant";
 import BookmarkView from "./BookmarkView";
-import {getRowColUpdatedFiles} from "../utils/getRowColUpdatedFiles";
-import {useEventHandler} from "../hooks/useEventHandler";
-import {rootStore} from "../store/rootStore";
+import { getRowColUpdatedFiles } from "../utils/getRowColUpdatedFiles";
+import { useEventHandler } from "../hooks/useEventHandler";
+import { rootStore } from "../store/rootStore";
 import BookmarkApi from "../utils/bookmarkApi";
 
 export interface DarkModeEvent {
@@ -26,17 +26,17 @@ type Props = {
   timestamp: string;
 };
 
-const Bookshelf: FC<Props> = ({folder, navigateTo, timestamp}) => {
-  const {children: files = []} = folder;
+const Bookshelf: FC<Props> = ({ folder, navigateTo, timestamp }) => {
+  const { children: files = [] } = folder;
   const {
     updateFilesLayout,
     dragAndDrop = {},
-    focus: {focusedIds},
+    focus: { focusedIds, focusCursor },
     refreshBookmark,
     edit,
     setEdit,
   } = rootStore();
-  const {bookmark: draggingFile, timestamp: draggingFileTimestamp} =
+  const { bookmark: draggingFile, timestamp: draggingFileTimestamp } =
     dragAndDrop;
 
   const originGridContainerRef = useRef<HTMLDivElement>(null);
@@ -47,7 +47,7 @@ const Bookshelf: FC<Props> = ({folder, navigateTo, timestamp}) => {
       handleMouseDownBookmark,
       handleMouseUpBookmark,
     },
-    bookshelfEventHandler: {handleMouseDownBookshelf, handleMouseUpBookshelf},
+    bookshelfEventHandler: { handleMouseDownBookshelf, handleMouseUpBookshelf },
   } = useEventHandler({
     bookshelf: folder,
     navigateTo,
@@ -97,6 +97,9 @@ const Bookshelf: FC<Props> = ({folder, navigateTo, timestamp}) => {
         const draggingFileTimestampId = `${draggingFileTimestamp}_${draggingFile?.id}`;
         const isFoscused = focusedIds.has(timestampId);
         const isDragging = draggingFileTimestampId === timestampId;
+        const isCurrentFocusCursor =
+          focusCursor?.currentBookshelf === timestamp &&
+          file.id === focusCursor?.target?.id;
 
         const isEdit = edit.timestampId === timestampId;
 
@@ -105,6 +108,7 @@ const Bookshelf: FC<Props> = ({folder, navigateTo, timestamp}) => {
             key={timestampId}
             bookmark={file}
             focused={isFoscused}
+            isCurrentFocusCursor={isCurrentFocusCursor}
             onSave={async (title) => handleSave(file.id, title)}
             onMouseDown={(e) =>
               handleMouseDownBookmark({

--- a/src/newtab/components/Bookshelf.tsx
+++ b/src/newtab/components/Bookshelf.tsx
@@ -99,7 +99,7 @@ const Bookshelf: FC<Props> = ({ folder, navigateTo, timestamp }) => {
         const isDragging = draggingFileTimestampId === timestampId;
         const isCurrentFocusCursor =
           focusCursor?.currentBookshelf === timestamp &&
-          file.id === focusCursor?.target?.id;
+          file.id === focusCursor?.targetId;
 
         const isEdit = edit.timestampId === timestampId;
 

--- a/src/newtab/components/Folder.tsx
+++ b/src/newtab/components/Folder.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type FC } from "react";
 import Bookshelf from "./Bookshelf";
 import Moveable from "react-moveable";
 import { Bookmark } from "../../types/store";
-import { MOUSE_CLICK, rootStore } from "../store/rootStore";
+import { rootStore } from "../store/rootStore";
 import CloseIcon from "../../assets/close.svg";
 import BackIcon from "../../assets/back.svg";
 import BackIconLG from "../../assets/back_lg.svg";

--- a/src/newtab/hooks/useEventHandler.ts
+++ b/src/newtab/hooks/useEventHandler.ts
@@ -30,12 +30,16 @@ export const useEventHandler = ({
     focus,
     removeFocus,
     moveFocus,
+    contextMenu,
   } = rootStore();
 
   const globalEventHandelr = {
     handleKeyDown: (e: KeyboardEvent) => {
       // textarea에서는 작동하지 않도록 함
-      if (e.target instanceof HTMLTextAreaElement) {
+      if (
+        e.target instanceof HTMLTextAreaElement &&
+        contextMenu.isContextMenuVisible
+      ) {
         return;
       }
 

--- a/src/newtab/hooks/useEventHandler.ts
+++ b/src/newtab/hooks/useEventHandler.ts
@@ -29,10 +29,21 @@ export const useEventHandler = ({
     setEdit,
     focus,
     removeFocus,
+    moveFocus,
   } = rootStore();
 
   const globalEventHandelr = {
-    //
+    handleKeyDown: (e: KeyboardEvent) => {
+      // textarea에서는 작동하지 않도록 함
+      if (e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      if (e.key.startsWith("Arrow")) {
+        e.preventDefault();
+        moveFocus(e.key);
+      }
+    },
   };
 
   const bookshelfEventHandler = {
@@ -124,11 +135,11 @@ export const useEventHandler = ({
           if (focus.focusedIds.has(timestampId)) {
             removeFocus([timestampId]);
           } else {
-            addFocus([timestampId]);
+            addFocus([timestampId], timestamp);
           }
         } else {
           clearFocus();
-          addFocus([timestampId]);
+          addFocus([timestampId], timestamp);
         }
 
         // move 에 대한 상태관리
@@ -155,7 +166,7 @@ export const useEventHandler = ({
 
         if (!focus.focusedIds.has(timestampId)) {
           clearFocus();
-          addFocus([timestampId]);
+          addFocus([timestampId], timestamp);
         }
 
         setContextMenu({

--- a/src/newtab/store/rootStore.ts
+++ b/src/newtab/store/rootStore.ts
@@ -41,6 +41,7 @@ type State = {
     // bookmark?: Bookmark;
     timestampId: string | null;
   };
+  layoutMap: LayoutMap;
 };
 
 type Action = {
@@ -95,7 +96,7 @@ export const rootStore = create<State & Action>()((set, get) => ({
     const layout = await layoutDB.getAllLayout();
     const bookmark = addRowColToTree(subTree, layout);
 
-    set({ bookmark });
+    set({ bookmark, layoutMap: layout });
   },
   getSubtree: (id) => {
     const bookmark = get().bookmark;
@@ -314,6 +315,10 @@ export const rootStore = create<State & Action>()((set, get) => ({
     });
 
     return targetPosition;
+  },
+  layoutMap: {},
+  setLayoutMap: (layoutMap: LayoutMap) => {
+    set({ layoutMap });
   },
 }));
 

--- a/src/newtab/store/rootStore.ts
+++ b/src/newtab/store/rootStore.ts
@@ -140,7 +140,7 @@ export const rootStore = create<State & Action>()((set, get) => ({
       focus: {
         focusedIds: newSet,
         focusCursor: {
-          target: layoutDB.getItemLayoutById(id),
+          target: get().layoutMap[id],
           currentBookshelf: bookshelfTimestamp,
         },
       },
@@ -195,7 +195,7 @@ export const rootStore = create<State & Action>()((set, get) => ({
         focus: {
           focusedIds: new Set([timestampId]),
           focusCursor: {
-            target: layoutDB.getItemLayoutById(id),
+            target: get().layoutMap[id],
             currentBookshelf,
           },
         },

--- a/src/newtab/store/rootStore.ts
+++ b/src/newtab/store/rootStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { Bookshelf, Bookmark, BookmarkType, Folders } from "../../types/store";
 import BookmarkApi from "../utils/bookmarkApi";
-import { ItemLayout, layoutDB, LayoutMap } from "../utils/layoutDB";
+import { layoutDB, LayoutMap } from "../utils/layoutDB";
 import { Point } from "../../types/Point";
 import { Z_INDEX, POSITION_OFFSET } from "../utils/constant";
 
@@ -20,7 +20,7 @@ type State = {
   };
   focus: {
     focusedIds: Set<string>;
-    focusCursor?: { target?: ItemLayout; currentBookshelf: string };
+    focusCursor?: { targetId?: string; currentBookshelf: string };
   };
   dragAndDrop?: {
     bookmark?: Bookmark;
@@ -140,7 +140,7 @@ export const rootStore = create<State & Action>()((set, get) => ({
       focus: {
         focusedIds: newSet,
         focusCursor: {
-          target: get().layoutMap[id],
+          targetId: id,
           currentBookshelf: bookshelfTimestamp,
         },
       },
@@ -160,10 +160,10 @@ export const rootStore = create<State & Action>()((set, get) => ({
     const { focusCursor } = get().focus;
     if (!focusCursor) return;
 
-    const { target, currentBookshelf } = focusCursor;
-    if (!target || !currentBookshelf) return;
+    const { targetId, currentBookshelf } = focusCursor;
+    if (!targetId || !currentBookshelf) return;
 
-    const { parentId, row, col } = target;
+    const { parentId, row, col } = get().layoutMap[targetId];
 
     const items = getItems({
       layoutMap: get().layoutMap,
@@ -218,7 +218,7 @@ export const rootStore = create<State & Action>()((set, get) => ({
         focus: {
           focusedIds: new Set([timestampId]),
           focusCursor: {
-            target: get().layoutMap[id],
+            targetId: id,
             currentBookshelf,
           },
         },

--- a/src/newtab/utils/layoutDB.ts
+++ b/src/newtab/utils/layoutDB.ts
@@ -57,13 +57,6 @@ class LayoutDB {
   async deleteItemLayoutById(id: string) {
     await this.db.delete(OBJECT_STORE_NAME, id);
   }
-
-  async getItemByRowCol({ parentId, row, col }: Omit<ItemLayout, "id">) {
-    return Object.values<ItemLayout>(this.layoutMap || {}).find(
-      (item) =>
-        item.col === col && item.row === row && item.parentId === parentId
-    );
-  }
 }
 
 export const layoutDB = new LayoutDB();

--- a/src/newtab/utils/layoutDB.ts
+++ b/src/newtab/utils/layoutDB.ts
@@ -4,7 +4,7 @@ export interface LayoutMap {
   [id: string]: ItemLayout; // key는 Item의 id, desktop === 1
 }
 
-interface ItemLayout {
+export interface ItemLayout {
   id: string;
   parentId: string;
   row: number;
@@ -25,6 +25,7 @@ const parseLayoutData = (layoutDataArray: ItemLayout[]) => {
 
 class LayoutDB {
   private db!: IDBPDatabase<LayoutMap>;
+  private layoutMap?: LayoutMap;
 
   async initDB() {
     this.db = await openDB<LayoutMap>(DB_NAME, DB_VERSION, {
@@ -44,11 +45,13 @@ class LayoutDB {
     const result = await this.db.getAll(OBJECT_STORE_NAME);
     const layoutMap = parseLayoutData(result);
 
+    this.layoutMap = layoutMap;
+
     return layoutMap;
   }
 
-  async getItemLayoutById(id: string): Promise<ItemLayout | undefined> {
-    return await this.db.get(OBJECT_STORE_NAME, id);
+  getItemLayoutById(id: string) {
+    return this.layoutMap?.[id];
   }
 
   async setItemLayoutById({ id, parentId, row, col }: ItemLayout) {
@@ -57,6 +60,13 @@ class LayoutDB {
 
   async deleteItemLayoutById(id: string) {
     await this.db.delete(OBJECT_STORE_NAME, id);
+  }
+
+  async getItemByRowCol({ parentId, row, col }: Omit<ItemLayout, "id">) {
+    return Object.values<ItemLayout>(this.layoutMap || {}).find(
+      (item) =>
+        item.col === col && item.row === row && item.parentId === parentId
+    );
   }
 }
 

--- a/src/newtab/utils/layoutDB.ts
+++ b/src/newtab/utils/layoutDB.ts
@@ -50,10 +50,6 @@ class LayoutDB {
     return layoutMap;
   }
 
-  getItemLayoutById(id: string) {
-    return this.layoutMap?.[id];
-  }
-
   async setItemLayoutById({ id, parentId, row, col }: ItemLayout) {
     await this.db.put(OBJECT_STORE_NAME, { id, parentId, row, col });
   }

--- a/src/pages/Desktop.tsx
+++ b/src/pages/Desktop.tsx
@@ -4,11 +4,15 @@ import FolderManager from "../newtab/components/FolderManager";
 import ContextMenu from "../newtab/components/ContextMenu";
 import { rootStore } from "../newtab/store/rootStore";
 import DraggingFile from "../newtab/components/DraggingFile";
+import { useEventHandler } from "../newtab/hooks/useEventHandler";
 
 const DESKTOP_TIMESTAMP_ID = `${Date.now()}`;
 
 const Desktop: FC = () => {
   const { bookmark, refreshBookmark, isDragging } = rootStore();
+  const {
+    globalEventHandelr: { handleKeyDown },
+  } = useEventHandler({});
 
   const setBookmarksEventHandlers = useCallback(() => {
     chrome.bookmarks.onCreated.addListener(() => {
@@ -27,6 +31,13 @@ const Desktop: FC = () => {
     refreshBookmark();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   return (
     <div className="size-full">


### PR DESCRIPTION
## 주요 변경 사항

- focusCursor를 추가했습니다.
  - addFocus 시에 focusCursor도 같이 세팅해주도록 했습니다.
  - focusCursor에서 현재 폴더를 알아야해서 timeStamp를 addFocus의 인자로 넘기도록 했습니다.
- moveFocus 함수를 추가했습니다.
  - 키보드 입력 시에 현재 row, col보다 바로 다음 아이템을 찾도록 했어요.
  - 참고) 2차원 배열로 하지 않고, row,col으로 북마크를 찾도록 했습니다.
- ~layoutDB에 layoutMap을 상태로 가지도록 했습니다.~ rootStore에서 관리하도록 했습니다.
- BookmarkView에 현재 focusCursor의 대상인지 아닌지 판단하도록 하고 대상이면 브라우저 focus를 옮기도록 했습니다.
  - 안그러면 enter로 수정이 안되어서 요렇게 했어요.
  - button에 outline을 제거했습니다.