### PR TITLE
fix: img 태그가 이벤트 대상에서 제외되도록 css 추가

### DIFF
--- a/src/newtab/components/BookmarkView.tsx
+++ b/src/newtab/components/BookmarkView.tsx
@@ -136,6 +136,7 @@ const BookmarkView = ({
 
               {showImgIcon && (
                 <img
+                  className="pointer-events-none"
                   src={PREFIX + bookmark.url}
                   onLoad={(e) => {
                     const targetImg = e.target as HTMLImageElement;


### PR DESCRIPTION
## 주요 변경사항

- 기존에 img가 이벤트를 먹어서 드래깅이 제대로 동작하지 않았습니다.
- 이벤트 대상에서 제외되도록 했어요.

### as-is

https://github.com/user-attachments/assets/9d409f1c-d134-468e-9a8a-473d18811396

### to-be

https://github.com/user-attachments/assets/a89b0602-e4a0-42f0-b2cc-241c0c6e09f1






