### PR TITLE
fix: 같은 폴더 move 시 북마크 재생성되지 않도록

### DIFF
--- a/src/newtab/hooks/useEventHandler.ts
+++ b/src/newtab/hooks/useEventHandler.ts
@@ -97,7 +97,6 @@ export const useEventHandler = ({
         row,
         col,
       });
-      await BookmarkApi.move(id, parentId);
 
       flush();
       refreshBookmark();


### PR DESCRIPTION
- 같은 폴더에서 move 시 bookmark move api를 호출하면 새롭게 북마크가 생성되므로 api를 호출하지 도록 수정