### PR TITLE
fix: 북마크 삭제 시 레이아웃 DB에서 삭제하는 기능 추가

### DIFF
--- a/src/newtab/components/ContextMenu.tsx
+++ b/src/newtab/components/ContextMenu.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from "react";
 import { rootStore } from "../store/rootStore";
 import BookmarkApi from "../utils/bookmarkApi";
 import { Z_INDEX } from "../utils/constant";
+import { layoutDB } from "../utils/layoutDB";
 
 interface ContextMenu {
   title: string;
@@ -41,7 +42,7 @@ const ContextMenu = () => {
           isOpen: true,
           bookmark: target[0],
         });
-        setContextMenu({isContextMenuVisible: false});
+        setContextMenu({ isContextMenuVisible: false });
       },
     };
     const 이름변경 = {
@@ -61,6 +62,7 @@ const ContextMenu = () => {
           /** 다 삭제 */
           const bookmarkId = timestampId.split("_")[1];
           bookmarkId && BookmarkApi.recursiveRemove(bookmarkId);
+          bookmarkId && layoutDB.deleteItemLayoutById(bookmarkId);
         });
         setContextMenu({ isContextMenuVisible: false });
       },

--- a/src/newtab/components/InfoDialog.tsx
+++ b/src/newtab/components/InfoDialog.tsx
@@ -3,6 +3,7 @@ import { rootStore } from "../store/rootStore";
 
 import BookmarkApi from "../utils/bookmarkApi";
 import { Z_INDEX } from "../utils/constant";
+import { layoutDB } from "../utils/layoutDB";
 
 const InfoDialog = () => {
   const { editDialog, setEditDialog, refreshBookmark } = rootStore();
@@ -26,6 +27,7 @@ const InfoDialog = () => {
       return;
     }
     await BookmarkApi.recursiveRemove(bookmark.id);
+    await layoutDB.deleteItemLayoutById(bookmark.id);
     handleCloseButtonClick();
     refreshBookmark();
   };

--- a/src/newtab/components/InfoDialog.tsx
+++ b/src/newtab/components/InfoDialog.tsx
@@ -1,17 +1,17 @@
-import {useEffect, useRef, useState} from "react";
-import {rootStore} from "../store/rootStore";
+import { useEffect, useRef, useState } from "react";
+import { rootStore } from "../store/rootStore";
 
 import BookmarkApi from "../utils/bookmarkApi";
-import {Z_INDEX} from "../utils/constant";
+import { Z_INDEX } from "../utils/constant";
 
 const InfoDialog = () => {
-  const {editDialog, setEditDialog, refreshBookmark} = rootStore();
-  const {bookmark, isOpen} = editDialog;
+  const { editDialog, setEditDialog, refreshBookmark } = rootStore();
+  const { bookmark, isOpen } = editDialog;
   const titleRef = useRef<HTMLInputElement>(null);
   const urlRef = useRef<HTMLInputElement>(null);
 
   const handleCloseButtonClick = () => {
-    setEditDialog({isOpen: false, bookmark: null});
+    setEditDialog({ isOpen: false, bookmark: null });
   };
   const handleSaveButtonClick = async () => {
     if (!bookmark) {
@@ -25,7 +25,7 @@ const InfoDialog = () => {
     if (!bookmark) {
       return;
     }
-    await BookmarkApi.remove(bookmark.id);
+    await BookmarkApi.recursiveRemove(bookmark.id);
     handleCloseButtonClick();
     refreshBookmark();
   };

--- a/src/pages/Desktop.tsx
+++ b/src/pages/Desktop.tsx
@@ -1,19 +1,21 @@
-import {FC, useCallback, useEffect} from "react";
+import { FC, useCallback, useEffect } from "react";
 import Bookshelf from "../newtab/components/Bookshelf";
 import FolderManager from "../newtab/components/FolderManager";
 import ContextMenu from "../newtab/components/ContextMenu";
-import {rootStore} from "../newtab/store/rootStore";
+import { rootStore } from "../newtab/store/rootStore";
 import DraggingFile from "../newtab/components/DraggingFile";
 import InfoDialog from "../newtab/components/InfoDialog";
-import {useEventHandler} from "../newtab/hooks/useEventHandler";
+import { useEventHandler } from "../newtab/hooks/useEventHandler";
 import Search from "../newtab/components/search/Search";
+import { layoutDB } from "../newtab/utils/layoutDB";
+import BookmarkApi from "../newtab/utils/bookmarkApi";
 
 const DESKTOP_TIMESTAMP_ID = `${Date.now()}`;
 
 const Desktop: FC = () => {
-  const {bookmark, refreshBookmark, isDragging} = rootStore();
+  const { bookmark, refreshBookmark, isDragging } = rootStore();
   const {
-    globalEventHandelr: {handleKeyDown},
+    globalEventHandelr: { handleKeyDown },
   } = useEventHandler({});
 
   const setBookmarksEventHandlers = useCallback(() => {
@@ -30,7 +32,35 @@ const Desktop: FC = () => {
 
   useEffect(() => {
     setBookmarksEventHandlers();
-    refreshBookmark();
+    refreshBookmark().then(async () => {
+      /*
+       * @NOTE: 북마크 삭제에 따른 레이아웃 삭제 기능이 추가된 버전에서 필요한 코드
+       * - 북마크 삭제에 따른 레이아웃 삭제 기능이 추가된 버전의 다음 버전에서는 삭제되어야할 코드
+       */
+      const layoutMap = await layoutDB.getAllLayout();
+
+      const deleteIdPromises = Object.values(layoutMap).map((item) => {
+        return new Promise<string | undefined>((res) =>
+          BookmarkApi.getSubTree(item.id)
+            .then(() => res(undefined))
+            .catch((e) => {
+              if (e instanceof Error && "message" in e) {
+                if (e.message.includes("Can't find bookmark for id.")) {
+                  res(item.id);
+                }
+              }
+            })
+        );
+      });
+
+      const deletedIds = (await Promise.all(deleteIdPromises)).filter(
+        (id) => id !== undefined
+      );
+
+      deletedIds.forEach((id) => {
+        layoutDB.deleteItemLayoutById(id);
+      });
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
## 주요 변경 사항

- 북마크 삭제 시 레이아웃 DB에서 삭제하는 기능 추가
- 레이아웃 DB를 기준으로 해당 id를 bookmark API를 찾을 수 없다면 layoutDB에서 해당 id를 삭제하는 로직 구현