### PR TITLE
fix: 드래그 중 화면 밖에서 mouseUp 시 드래그 상태 초기화

### DIFF
--- a/src/newtab/hooks/useEventHandler.ts
+++ b/src/newtab/hooks/useEventHandler.ts
@@ -48,6 +48,13 @@ export const useEventHandler = ({
         moveFocus(e.key);
       }
     },
+    handleMouseUp: async (e: MouseEvent) => {
+      const { pageX, pageY } = e;
+      if (pageX <= 0 || pageY <= 0) {
+        await refreshBookmark();
+        flush();
+      }
+    },
   };
 
   const bookshelfEventHandler = {

--- a/src/pages/Desktop.tsx
+++ b/src/pages/Desktop.tsx
@@ -15,7 +15,7 @@ const DESKTOP_TIMESTAMP_ID = `${Date.now()}`;
 const Desktop: FC = () => {
   const { bookmark, refreshBookmark, isDragging } = rootStore();
   const {
-    globalEventHandelr: { handleKeyDown },
+    globalEventHandelr: { handleKeyDown, handleMouseUp },
   } = useEventHandler({});
 
   const setBookmarksEventHandlers = useCallback(() => {
@@ -69,10 +69,12 @@ const Desktop: FC = () => {
 
   useEffect(() => {
     window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("mouseup", handleMouseUp);
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [handleKeyDown]);
+  }, [handleKeyDown, handleMouseUp]);
 
   return (
     <div className="size-full">


### PR DESCRIPTION
- 드래그 중 화면 밖에서 mouseUp 시 드래그 상태를 초기화 합니다.
   window에 mouseup 이벤트 추가 후, pageX / pageY 좌표가 -1일 경우 화면 밖에서 drop했다고 판단하여 refresh & flush 합니다.
